### PR TITLE
fix(adapty-ui): render product text on first composition before produ…

### DIFF
--- a/adapty-ui/src/main/java/com/adapty/ui/AdaptyPaywallView.kt
+++ b/adapty-ui/src/main/java/com/adapty/ui/AdaptyPaywallView.kt
@@ -36,6 +36,8 @@ public class AdaptyPaywallView @JvmOverloads constructor(
     defStyleAttr: Int = 0,
 ) : AbstractComposeView(context, attrs, defStyleAttr) {
 
+    private val instanceKey: String = UUID.randomUUID().toString()
+
     private val viewModel: PaywallViewModel? by lazy {
         val viewModelStoreOwner = findViewTreeViewModelStoreOwner()
             ?: run {
@@ -43,12 +45,12 @@ public class AdaptyPaywallView @JvmOverloads constructor(
                 return@lazy null
             }
         PaywallViewModelArgs.create(
-            "${UUID.randomUUID().toString().hashCode()}",
+            "${instanceKey.hashCode()}",
             null,
             context.getCurrentLocale(),
         )?.let { args ->
             val factory = PaywallViewModelFactory(args)
-            ViewModelProvider(viewModelStoreOwner, factory)[PaywallViewModel::class.java]
+            ViewModelProvider(viewModelStoreOwner, factory)[instanceKey, PaywallViewModel::class.java]
         }
     }
 

--- a/adapty-ui/src/main/java/com/adapty/ui/internal/text/TextResolver.kt
+++ b/adapty-ui/src/main/java/com/adapty/ui/internal/text/TextResolver.kt
@@ -52,8 +52,8 @@ internal class TextResolver(
                 val desiredProductId = stringId.productId?.takeIf { it.isNotEmpty() }
                     ?: state[getProductGroupKey(stringId.productGroupId)] as? String
                 val desiredLocalText = if (!desiredProductId.isNullOrEmpty()) {
-                    val product = products[desiredProductId] ?: return StringWrapper.EMPTY
-                    val paymentModeStr = when(product.firstDiscountOfferOrNull()?.paymentMode) {
+                    val product = products[desiredProductId]
+                    val paymentModeStr = when(product?.firstDiscountOfferOrNull()?.paymentMode) {
                         PaymentMode.FREE_TRIAL -> "free_trial"
                         PaymentMode.PAY_AS_YOU_GO -> "pay_as_you_go"
                         PaymentMode.PAY_UPFRONT -> "pay_up_front"

--- a/adapty-ui/src/main/java/com/adapty/ui/internal/ui/element/BaseTextElement.kt
+++ b/adapty-ui/src/main/java/com/adapty/ui/internal/ui/element/BaseTextElement.kt
@@ -111,7 +111,6 @@ public abstract class BaseTextElement(
                     Text(
                         text = annotatedText,
                         maxLines = maxLines ?: Int.MAX_VALUE,
-                        lineHeight = fontSizeSp,
                         textAlign = textAlign.toComposeTextAlign(),
                         onTextLayout = createOnTextLayoutCallback(onOverflow, fontSize, readyToDraw),
                         overflow = TextOverflow.Ellipsis,
@@ -127,7 +126,6 @@ public abstract class BaseTextElement(
                         maxLines = maxLines ?: Int.MAX_VALUE,
                         fontFamily = text.attrs?.fontFamily ?: elementTextAttrs.fontFamily,
                         fontSize = fontSizeSp,
-                        lineHeight = fontSizeSp,
                         textDecoration = text.attrs?.textDecoration ?: elementTextAttrs.textDecoration,
                         textAlign = textAlign.toComposeTextAlign(),
                         onTextLayout = createOnTextLayoutCallback(onOverflow, fontSize, readyToDraw),
@@ -160,7 +158,6 @@ public abstract class BaseTextElement(
                     maxLines = maxLines ?: Int.MAX_VALUE,
                     fontFamily = elementTextAttrs.fontFamily,
                     fontSize = fontSizeSp,
-                    lineHeight = fontSizeSp,
                     textDecoration = elementTextAttrs.textDecoration,
                     textAlign = textAlign.toComposeTextAlign(),
                     onTextLayout = createOnTextLayoutCallback(onOverflow, fontSize, readyToDraw),


### PR DESCRIPTION
`TextResolver.resolve` returned `StringWrapper.EMPTY` whenever `products[desiredProductId]` was `null`, which blanked the Purchase Button label (and Products text) on the first launch of an Android paywall, even for literal labels with no product-dependent tags. The label only appeared after dismissing and reopening, once the SDK had cached the products.

Match the iOS path (AdaptyUITextView's placeholder branch): drop the early return and let the resolver continue with a nullable product. The default-payment-mode lookup returns the configured text immediately, and recomposition fills in tag-resolved values once products arrive.