### PR TITLE
fix(adapty-ui): use natural line height to prevent descender clipping and false overflow scaling

### DIFF
--- a/adapty-ui/src/main/java/com/adapty/ui/internal/ui/element/BaseTextElement.kt
+++ b/adapty-ui/src/main/java/com/adapty/ui/internal/ui/element/BaseTextElement.kt
@@ -111,7 +111,6 @@ public abstract class BaseTextElement(
                     Text(
                         text = annotatedText,
                         maxLines = maxLines ?: Int.MAX_VALUE,
-                        lineHeight = fontSizeSp,
                         textAlign = textAlign.toComposeTextAlign(),
                         onTextLayout = createOnTextLayoutCallback(onOverflow, fontSize, readyToDraw),
                         overflow = TextOverflow.Ellipsis,
@@ -127,7 +126,6 @@ public abstract class BaseTextElement(
                         maxLines = maxLines ?: Int.MAX_VALUE,
                         fontFamily = text.attrs?.fontFamily ?: elementTextAttrs.fontFamily,
                         fontSize = fontSizeSp,
-                        lineHeight = fontSizeSp,
                         textDecoration = text.attrs?.textDecoration ?: elementTextAttrs.textDecoration,
                         textAlign = textAlign.toComposeTextAlign(),
                         onTextLayout = createOnTextLayoutCallback(onOverflow, fontSize, readyToDraw),
@@ -160,7 +158,6 @@ public abstract class BaseTextElement(
                     maxLines = maxLines ?: Int.MAX_VALUE,
                     fontFamily = elementTextAttrs.fontFamily,
                     fontSize = fontSizeSp,
-                    lineHeight = fontSizeSp,
                     textDecoration = elementTextAttrs.textDecoration,
                     textAlign = textAlign.toComposeTextAlign(),
                     onTextLayout = createOnTextLayoutCallback(onOverflow, fontSize, readyToDraw),


### PR DESCRIPTION
When a text element uses the paywall builder's scale-on-overflow mode, any string containing letters with descenders (j, y, g, p, q) is clipped at the baseline and can be repeatedly scaled down far below its configured font size.

`renderTextInternal` forces `lineHeight` equal to `fontSize`, constraining the line box to 1.0 em, while glyphs with descenders need roughly 1.2 em. The descender paints below the measured bounds, so `TextOverflow.Ellipsis` clips it at the baseline and the layout falsely reports `didOverflowHeight`, which makes `OnOverflowMode.SCALE` shrink the text again on every layout pass.

Leave `lineHeight` unspecified so the font's natural metrics apply. The first layout then measures a box that includes descent, descenders no longer clip or register as height overflow, and scale-on-overflow still handles genuine width overflows.